### PR TITLE
Fix: Broken Wallets, Terms and Orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Então, nesta parte vamos ter 2 etapas de configuração.
 - **Debug:** campo que possibilita a ativação e a desativação da ferramente debug do módulo:
   - Sim - as requisições e respostas serão armazenadas em um arquivo chamado "shipay.log".
   - Não - as requisições e respostas não serão armazenadas.
+- **Base URL:** URL base do site (necessário preencher somente em caso de haver extras na URL Ex: `https://shipay.com.br/(extra1)/(extra2)`).
 
 
 

--- a/app/code/community/Shipay/Magento19/etc/system.xml
+++ b/app/code/community/Shipay/Magento19/etc/system.xml
@@ -69,6 +69,15 @@
               <show_in_website>1</show_in_website>
               <show_in_store>0</show_in_store>
             </debug>
+            <base_url translate="label">
+              <label>Base URL</label>
+              <frontend_type>text</frontend_type>
+              <sort_order>90</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>0</show_in_store>
+              <comment>URL base do site (necessário preencher somente em caso de haver extras na URL Ex: https://shipay.com.br/(extra1)/(extra2))</comment>
+            </base_url>
           </fields>
         </shipay_payments>
 

--- a/app/design/frontend/base/default/template/shipay/magento19/form/payment.phtml
+++ b/app/design/frontend/base/default/template/shipay/magento19/form/payment.phtml
@@ -39,6 +39,7 @@
 
         <input type="hidden" class="validate-method-payment" id="wallet-name" name="payment[wallet-name]" />
         <input type="hidden" id="pix-dict-key" name="payment[pix-dict-key]" />
+        <input type="hidden" id="shipay-base-url" value="<?= Mage::getStoreConfig('payment/shipay_payments/base_url') ?>" />
 
         <div class="methods">
             <?php foreach ($arrayWallets as $wallet) : ?>

--- a/js/shipay/shipay.js
+++ b/js/shipay/shipay.js
@@ -47,7 +47,7 @@ function maskPostalCode(cep) {
 }
 
 function openTermsPopup() {
-  var baseUrl = window.origin;
+  var baseUrl = Mage::getStoreConfig('payment/shipay_payments/base_url') ? Mage::getStoreConfig('payment/shipay_payments/base_url') : window.origin;
   var dataHtml = '';
 
   fetch(`${baseUrl}/shipaymagento19/terms`)

--- a/js/shipay/shipay.js
+++ b/js/shipay/shipay.js
@@ -47,7 +47,7 @@ function maskPostalCode(cep) {
 }
 
 function openTermsPopup() {
-  var baseUrl = Mage::getStoreConfig('payment/shipay_payments/base_url') ? Mage::getStoreConfig('payment/shipay_payments/base_url') : window.origin;
+  var baseUrl = document.getElementById("shipay-base-url").value ? document.getElementById("shipay-base-url").value : window.origin;
   var dataHtml = '';
 
   fetch(`${baseUrl}/shipaymagento19/terms`)

--- a/skin/frontend/base/default/js/form-shipay.js
+++ b/skin/frontend/base/default/js/form-shipay.js
@@ -1,7 +1,7 @@
 let arrayWallets;
 
 setInterval(function () {
-    var baseUrl = window.origin;
+    var baseUrl = Mage::getStoreConfig('payment/shipay_payments/base_url') ? Mage::getStoreConfig('payment/shipay_payments/base_url') : window.origin;
     var orderId = document.getElementById('orderid').value;
 
     if (orderId) {
@@ -35,7 +35,7 @@ function copyTextSucess() {
 }
 
 function getWallets() {
-    var baseUrl = window.origin;
+    var baseUrl = Mage::getStoreConfig('payment/shipay_payments/base_url') ? Mage::getStoreConfig('payment/shipay_payments/base_url') : window.origin;
 
     fetch(`${baseUrl}/shipaymagento19/wallets`)
         .then(response => response.json())

--- a/skin/frontend/base/default/js/form-shipay.js
+++ b/skin/frontend/base/default/js/form-shipay.js
@@ -1,7 +1,7 @@
 let arrayWallets;
 
 setInterval(function () {
-    var baseUrl = Mage::getStoreConfig('payment/shipay_payments/base_url') ? Mage::getStoreConfig('payment/shipay_payments/base_url') : window.origin;
+    var baseUrl = document.getElementById("shipay-base-url").value ? document.getElementById("shipay-base-url").value : window.origin;
     var orderId = document.getElementById('orderid').value;
 
     if (orderId) {
@@ -35,7 +35,7 @@ function copyTextSucess() {
 }
 
 function getWallets() {
-    var baseUrl = Mage::getStoreConfig('payment/shipay_payments/base_url') ? Mage::getStoreConfig('payment/shipay_payments/base_url') : window.origin;
+    var baseUrl = document.getElementById("shipay-base-url").value ? document.getElementById("shipay-base-url").value : window.origin;
 
     fetch(`${baseUrl}/shipaymagento19/wallets`)
         .then(response => response.json())


### PR DESCRIPTION
O erro estava sendo causado pela parte extra da URL em lojas/servidores não totalmente configurados. A URL base que estava sendo usada era algo parecido com "http://magento.shipay.com.br/shipaymagento19/wallets" (normal para as lojas configuradas e motivo da dificuldade em reproduzir o problema), no entanto como a loja não havia sido totalmente configurada (htaccess e afins), a URL que deveria estar sendo utilizada para obter as carteiras, por exemplo, deveria ser "https://magento.shipay.com.br/index.php/shipaymagento19/wallets".
Assim, a solução encontrada para contornar o problema por meio do código foi um campo no painel que caso preenchido substituirá a URL utilizada, caso contrário a URL padrão será utilizada.