### PR TITLE
Feat/14797 cnpj alfanumerico

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @shipay-pag/corepayments-codeowners

--- a/app/code/community/Shipay/Magento19/Resource/GetTaxVat.php
+++ b/app/code/community/Shipay/Magento19/Resource/GetTaxVat.php
@@ -13,11 +13,20 @@ class Shipay_Magento19_Resource_GetTaxVat {
     $taxDocument = Mage::getStoreConfig('payment/shipay_payments/capture_tax', $storeId);
     if ($taxDocument) {
       $document = $data['client_document'];
-      return preg_replace('/[^0-9]/is', '', $document);
+      return $this->normalizeDocument($document);
     } else {
       $customer = Mage::getModel('customer/customer')->load($customerId);
       $document = $customer->getData('taxvat');
-      return preg_replace('/[^0-9]/is', '', $document);
+      return $this->normalizeDocument($document);
     }
+  }
+
+  /**
+   * Function to normalize document
+   * @param string $document
+   * @return string
+   */
+  protected function normalizeDocument($document): string {
+    return strtoupper(preg_replace('/[^A-Z0-9]/i', '', $document));
   }
 }

--- a/app/code/community/Shipay/Magento19/Validation/DocumentValidator.php
+++ b/app/code/community/Shipay/Magento19/Validation/DocumentValidator.php
@@ -8,14 +8,23 @@ class Shipay_Magento19_Validation_DocumentValidator {
    * @return bool
    */
   public function validateDocument($document) {
-    $document = preg_replace('/[^0-9]/is', '', $document);
-    if (strlen($document) == 11) {
+    $document = $this->normalizeDocument($document);
+    if (preg_match('/^\d{11}$/', $document)) {
       return $this->validateDocumentCpf($document);
     } else if (strlen($document) == 14) {
       return $this->validateDocumentCnpj($document);
     } else {
       return false;
     }
+  }
+
+  /**
+   * Function to normalize document
+   * @param string $document
+   * @return string
+   */
+  protected function normalizeDocument($document) {
+    return strtoupper(preg_replace('/[^A-Z0-9]/i', '', $document));
   }
 
   /**
@@ -45,12 +54,16 @@ class Shipay_Magento19_Validation_DocumentValidator {
    * @return bool
    */
   protected function validateDocumentCnpj($document) {
+    if (!preg_match('/^[A-Z0-9]{12}\d{2}$/', $document)) {
+      return false;
+    }
+
     if (preg_match('/(\d)\1{13}/', $document)) {
       return false;
     }
 
     for ($i = 0, $j = 5, $soma = 0; $i < 12; $i++) {
-      $soma += $document[$i] * $j;
+      $soma += $this->getCnpjCharValue($document[$i]) * $j;
       $j = ($j == 2) ? 9 : $j - 1;
     }
 
@@ -60,12 +73,21 @@ class Shipay_Magento19_Validation_DocumentValidator {
       return false;
 
     for ($i = 0, $j = 6, $soma = 0; $i < 13; $i++) {
-      $soma += $document[$i] * $j;
+      $soma += $this->getCnpjCharValue($document[$i]) * $j;
       $j = ($j == 2) ? 9 : $j - 1;
     }
 
     $resto = $soma % 11;
 
     return $document[13] == ($resto < 2 ? 0 : 11 - $resto);
+  }
+
+  /**
+   * Function to get cnpj character value
+   * @param string $char
+   * @return int
+   */
+  protected function getCnpjCharValue($char) {
+    return ord($char) - 48;
   }
 }

--- a/js/shipay/shipay.js
+++ b/js/shipay/shipay.js
@@ -11,19 +11,22 @@ function termsAccepted() {
 }
 
 function maskDocument(document) {
-  const i = document.value.length;
-  if (i == 11) {
-    document.value = maskCpf(document.value);
+  const value = normalizeDocument(document.value);
+  if (/^\d{11}$/.test(value)) {
+    document.value = maskCpf(value);
+    return;
   }
-  if (i == 15) {
-    document.value = document.value.replace(/[\.-]/g, "");
+
+  if (value.length >= 14) {
+    document.value = maskCnpj(value.substring(0, 14));
+    return;
   }
-  if (i == 14) {
-    document.value = maskCnpj(document.value);
-  }
-  if (i < 14 && i > 11) {
-    document.value = document.value.replace(/[\.-]/g, "");
-  }
+
+  document.value = value;
+}
+
+function normalizeDocument(document) {
+  return document.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
 }
 
 function maskCpf(cpf) {
@@ -35,7 +38,8 @@ function maskCpf(cpf) {
 }
 
 function maskCnpj(cnpj) {
-  cnpj = (cnpj.replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, "$1.$2.$3/$4-$5"));
+  cnpj = normalizeDocument(cnpj);
+  cnpj = (cnpj.replace(/^([A-Z0-9]{2})([A-Z0-9]{3})([A-Z0-9]{3})([A-Z0-9]{4})(\d{2})/, "$1.$2.$3/$4-$5"));
   return cnpj;
 }
 
@@ -99,9 +103,8 @@ Validation.addAllThese([
   }],
 
   ['validate-document', 'Documento inválido. Verifique por favor', function (v) {
-    const tamDocument = v.length;
-    if (tamDocument == 14) {
-      v = v.replace(/\D/g, '');
+    v = normalizeDocument(v);
+    if (/^\d{11}$/.test(v)) {
       if (v.toString().length != 11 || /^(\d)\1{10}$/.test(v)) return false;
       var result = true;
       [9, 10].forEach(function (j) {
@@ -115,13 +118,8 @@ Validation.addAllThese([
       });
       return result;
     }
-    else if (tamDocument == 18) {
-      var cnpj = v.trim();
-
-      cnpj = cnpj.replace(/\./g, '');
-      cnpj = cnpj.replace('-', '');
-      cnpj = cnpj.replace('/', '');
-      cnpj = cnpj.split('');
+    else if (/^[A-Z0-9]{12}\d{2}$/.test(v)) {
+      var cnpj = v.split('');
 
       var v1 = 0;
       var v2 = 0;
@@ -139,9 +137,9 @@ Validation.addAllThese([
 
       for (var i = 0, p1 = 5, p2 = 13; (cnpj.length - 2) > i; i++, p1--, p2--) {
         if (p1 >= 2) {
-          v1 += cnpj[i] * p1;
+          v1 += getCnpjCharValue(cnpj[i]) * p1;
         } else {
-          v1 += cnpj[i] * p2;
+          v1 += getCnpjCharValue(cnpj[i]) * p2;
         }
       }
 
@@ -159,9 +157,9 @@ Validation.addAllThese([
 
       for (var i = 0, p1 = 6, p2 = 14; (cnpj.length - 1) > i; i++, p1--, p2--) {
         if (p1 >= 2) {
-          v2 += cnpj[i] * p1;
+          v2 += getCnpjCharValue(cnpj[i]) * p1;
         } else {
-          v2 += cnpj[i] * p2;
+          v2 += getCnpjCharValue(cnpj[i]) * p2;
         }
       }
 
@@ -193,3 +191,7 @@ Validation.addAllThese([
     }
   }],
 ]);
+
+function getCnpjCharValue(value) {
+  return value.charCodeAt(0) - 48;
+}

--- a/skin/frontend/base/default/js/form-shipay.js
+++ b/skin/frontend/base/default/js/form-shipay.js
@@ -57,19 +57,22 @@ function typeMethodSelected(imageElement) {
 }
 
 function maskDocument(document) {
-    const i = document.value.length;
-    if (i == 11) {
-        document.value = maskCpf(document.value);
+    const value = normalizeDocument(document.value);
+    if (/^\d{11}$/.test(value)) {
+        document.value = maskCpf(value);
+        return;
     }
-    if (i == 15) {
-        document.value = document.value.replace(/[\.-]/g, "");
+
+    if (value.length >= 14) {
+        document.value = maskCnpj(value.substring(0, 14));
+        return;
     }
-    if (i == 14) {
-        document.value = maskCnpj(document.value);
-    }
-    if (i < 14 && i > 11) {
-        document.value = document.value.replace(/[\.-]/g, "");
-    }
+
+    document.value = value;
+}
+
+function normalizeDocument(document) {
+    return document.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
 }
 
 function maskCpf(cpf) {
@@ -81,15 +84,15 @@ function maskCpf(cpf) {
 }
 
 function maskCnpj(cnpj) {
-    cnpj = (cnpj.replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, "$1.$2.$3/$4-$5"));
+    cnpj = normalizeDocument(cnpj);
+    cnpj = (cnpj.replace(/^([A-Z0-9]{2})([A-Z0-9]{3})([A-Z0-9]{3})([A-Z0-9]{4})(\d{2})/, "$1.$2.$3/$4-$5"));
     return cnpj;
 }
 
 Validation.addAllThese([
     ['validate-document', 'Documento inválido. Verifique por favor.', function (v) {
-        const tamDocument = v.length;
-        if (tamDocument == 14) {
-            v = v.replace(/\D/g, '');
+        v = normalizeDocument(v);
+        if (/^\d{11}$/.test(v)) {
             if (v.toString().length != 11 || /^(\d)\1{10}$/.test(v)) return false;
             var result = true;
             [9, 10].forEach(function (j) {
@@ -103,13 +106,8 @@ Validation.addAllThese([
             });
             return result;
         }
-        else if (tamDocument == 18) {
-            var cnpj = v.trim();
-
-            cnpj = cnpj.replace(/\./g, '');
-            cnpj = cnpj.replace('-', '');
-            cnpj = cnpj.replace('/', '');
-            cnpj = cnpj.split('');
+        else if (/^[A-Z0-9]{12}\d{2}$/.test(v)) {
+            var cnpj = v.split('');
 
             var v1 = 0;
             var v2 = 0;
@@ -127,9 +125,9 @@ Validation.addAllThese([
 
             for (var i = 0, p1 = 5, p2 = 13; (cnpj.length - 2) > i; i++, p1--, p2--) {
                 if (p1 >= 2) {
-                    v1 += cnpj[i] * p1;
+                    v1 += getCnpjCharValue(cnpj[i]) * p1;
                 } else {
-                    v1 += cnpj[i] * p2;
+                    v1 += getCnpjCharValue(cnpj[i]) * p2;
                 }
             }
 
@@ -147,9 +145,9 @@ Validation.addAllThese([
 
             for (var i = 0, p1 = 6, p2 = 14; (cnpj.length - 1) > i; i++, p1--, p2--) {
                 if (p1 >= 2) {
-                    v2 += cnpj[i] * p1;
+                    v2 += getCnpjCharValue(cnpj[i]) * p1;
                 } else {
-                    v2 += cnpj[i] * p2;
+                    v2 += getCnpjCharValue(cnpj[i]) * p2;
                 }
             }
 
@@ -182,3 +180,7 @@ Validation.addAllThese([
         }
     }]
 ]);
+
+function getCnpjCharValue(value) {
+    return value.charCodeAt(0) - 48;
+}


### PR DESCRIPTION
Adequa validação e máscara de CPF/CNPJ para aceitar CNPJ alfanumérico.

- Preserva letras ao normalizar documentos antes da validação/envio
- Atualiza cálculo de DV do CNPJ para o padrão alfanumérico
- Mantém compatibilidade com CPF e CNPJ numérico atuais
- Ajusta máscaras/validação JS no admin e frontend